### PR TITLE
Revise template for Cycle 5 proposal calls

### DIFF
--- a/finance/proposal-calls/cycle5/template.md
+++ b/finance/proposal-calls/cycle5/template.md
@@ -9,22 +9,22 @@ How does this benefit Astropy packages / users / community / ...? Short summary.
 #### Roadmap Items
 What [roadmap](https://github.com/astropy/astropy-project/blob/main/roadmap/roadmap.md) item(s) does this work help address?
 
-### Project / Work
-Details here as needed for Astropy community members to understand what is planned.
+### Project / Work / Deliverables
+Details here as needed for Astropy community members to understand what is planned. This should include a description of expected concrete results or deliverables.
 
 ### Approximate Budget
 Currency: US $
 The approximate budget should be specified in USD. However, we are open to spending funds worldwide. Budgets should be converted to USD using a plausible exchange rate.
 
-Include overheads, fringe, etc. if money is paid as sub-grant (note that the Moore grant caps overhead at 15%).
+Include overheads, fringe, etc. if money is paid as sub-award to an institution.
 
 - Salary / contractor fees etc. (give sum here, details about contract, payment method (contract/sub-award) etc. can be worked out with the finance committee later)
 - TOTAL
 
 Please note that we would happily accept budget items other than the above.
 
-Travel and conference registration should be submitted separately as needed.
+Travel and conference registration should be submitted separately from this funding request, as needed.
 
 ### Period of Performance
 
-List the expected range of time the budget should be allocated for.
+List the expected range of time the budget should be allocated for. For Cycle 5, the ideal period of performance is Jan 1, 2026–Dec 31, 2026.


### PR DESCRIPTION
Updated the project/work section to clarify deliverables and revised budget details for sub-awards. Added specific period of performance for Cycle 5.